### PR TITLE
add argument point to `.add` method

### DIFF
--- a/tests/test_min.py
+++ b/tests/test_min.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from sbumed_predictions_to_graph import State
 
 
@@ -16,3 +18,34 @@ def test_min(tmpdir: Path):
     state.add(cell_type="lymphocyte", probability=0.80, polygon_coords=[(1, 1)])
     state.write()
     assert out_path.exists()
+
+
+def test_add_point(tmpdir: Path):
+    out_path = tmpdir / "test.ttl"
+    state = State(
+        path=out_path,
+        creator="Me",
+        name="test-output",
+        description="This is just a test.",
+        slide_path=__file__,
+        github_url="foobar.com",
+    )
+    with pytest.raises(ValueError):
+        state.add(
+            cell_type="lymphocyte",
+            probability=0.80,
+            polygon_coords=[(1, 1)],
+            point=[1, 2],
+        )
+    with pytest.raises(ValueError):
+        state.add(
+            cell_type="lymphocyte",
+            probability=0.80,
+            point=[1, 2, 3],
+        )
+    with pytest.raises(ValueError):
+        state.add(
+            cell_type="lymphocyte",
+            probability=0.80,
+            point=[1],
+        )


### PR DESCRIPTION
This is to support dot annotations.

Closes https://github.com/kaczmarj/model-inference-plugin-rdf/issues/2